### PR TITLE
feat: kubeadjust v0.2.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,64 @@
+name: Bug report
+description: Something is not working as expected
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug!
+
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: A clear description of the bug.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Go to namespace '...'
+        2. Open deployment '...'
+        3. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behaviour
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: KubeAdjust version
+      placeholder: "0.2.0"
+    validations:
+      required: true
+
+  - type: input
+    id: k8s
+    attributes:
+      label: Kubernetes version
+      placeholder: "1.29"
+
+  - type: dropdown
+    id: metrics
+    attributes:
+      label: metrics-server installed?
+      options:
+        - "Yes"
+        - "No"
+        - "Unknown"
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs
+      description: Backend logs, browser console errors, etc.
+      render: shell

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,25 @@
+name: Feature request
+description: Suggest a new feature or improvement
+labels: [enhancement]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: Describe the use case or pain point.
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: What would you like to see?
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Any other approaches you thought about?

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+## Summary
+
+<!-- What does this PR do? Why? -->
+
+## Changes
+
+<!-- List the main changes -->
+
+## Testing
+
+- [ ] `go vet ./...` passes
+- [ ] `npm run build` passes
+- [ ] Tested locally (real cluster or mock mode)
+- [ ] New Helm values documented in `values.yaml`
+- [ ] New env vars documented in README
+
+## Related issues
+
+<!-- Closes #... -->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  backend:
+    name: Go build & vet
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.22"
+          cache-dependency-path: backend/go.sum
+      - run: go build ./...
+      - run: go vet ./...
+
+  frontend:
+    name: Next.js build
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+      - run: npm ci
+      - run: npm run build

--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,12 @@
 # Go
 backend/vendor/
 
-.claude
-.env
-build.md
+# Claude workspace (project-specific AI instructions)
+.claude/
 CLAUDE.md
 
-docker-compose.yml
-
+# Personal build scripts
+build.md
 
 # Node
 frontend/node_modules/
@@ -16,3 +15,4 @@ frontend/.next/
 # Env
 .env
 .env.local
+.env*.local

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,37 @@
+# Changelog
+
+All notable changes to KubeAdjust are documented here.
+
+## [0.2.0] - 2026-02-22
+
+### Added
+- **Metrics-server detection**: warning banner displayed when metrics-server is not installed or unreachable
+- **Prometheus sparklines**: optional inline SVG CPU/memory trend graphs (last 1h) per container, loaded from an existing Prometheus — pure SVG, no charting library
+- **Optional Helm sub-chart**: metrics-server can be deployed as a Helm dependency (`metricsServer.enabled=true`)
+- **Prometheus Helm values**: `prometheus.enabled` + `prometheus.url` to inject `PROMETHEUS_URL` into the backend
+- New backend route `GET /api/namespaces/{ns}/prometheus/{pod}/{container}` for historical data
+
+### Changed
+- `/api/namespaces/{ns}/deployments` response now returns a `WorkloadResponse` envelope: `{ workloads, metricsAvailable, prometheusAvailable }` instead of a bare array
+- Helm chart version bumped to `0.2.0`
+
+---
+
+## [0.1.0] - 2026-02-20
+
+### Added
+- **Workload dashboard**: Deployments, StatefulSets and CronJobs in one view
+- **Resource bars**: CPU / Memory / Ephemeral Storage per container, with requests, limits and live usage
+- **Color-coded status**: Critical (≥90% of limit), Warning (≥70%), Over-provisioned (≤35% of request), Healthy
+- **PVC and emptyDir volumes**: capacity, usage, available per pod
+- **Suggestions panel**: grouped by resource type (CPU, Memory, Ephemeral — no limit, Ephemeral, PVC, EmptyDir); collapsible groups; sorted by severity
+- **Node overview**: capacity, allocatable, requested, limited, live usage per node
+- **StatefulSet + CronJob support**: owner-reference-based pod matching (replaces fragile prefix matching)
+- **Kind badge**: StatefulSet and CronJob workloads labelled in the UI
+- **All cards collapsed** by default for a clean overview
+- Mock mode: token `mock-dev-token` returns hardcoded demo data
+- Helm chart with read-only ClusterRole + ClusterRoleBinding
+- Multi-stage Docker builds (scratch image for backend)
+
+### Fixed
+- CPU metrics showing 0%: metrics-server returns nanocores (`18447n`) which were not parsed — now correctly converted to millicores

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,86 @@
+# Contributing to KubeAdjust
+
+Thank you for taking the time to contribute!
+
+## Getting started
+
+1. Fork the repository and clone your fork
+2. Create a feature branch: `git checkout -b feat/my-feature`
+3. Make your changes (see development setup below)
+4. Open a pull request against `main`
+
+## Development setup
+
+### Prerequisites
+
+- Go 1.22+
+- Node.js 20+
+- Docker + Docker Compose (optional)
+- A Kubernetes cluster, or use `mock-dev-token` for local UI development
+
+### Run locally
+
+```bash
+# Backend
+cd backend
+KUBE_API_SERVER=https://<your-cluster> KUBE_INSECURE_TLS=true go run .
+
+# Frontend (separate terminal)
+cd frontend
+npm install && npm run dev
+```
+
+Or with Docker Compose:
+
+```bash
+KUBE_API_SERVER=https://<your-cluster> docker compose up --build
+```
+
+### Mock mode
+
+Use token `mock-dev-token` at the login screen to load hardcoded demo data without a real cluster.
+
+## Project structure
+
+```
+backend/
+  main.go               # chi router + routes
+  k8s/client.go         # raw HTTP client to k8s API (no client-go)
+  prometheus/client.go  # optional Prometheus client
+  middleware/auth.go    # Bearer token extraction
+  handlers/
+    resources.go        # main workloads handler
+    nodes.go
+    auth.go
+    prometheus.go       # history endpoint
+
+frontend/src/
+  lib/api.ts            # typed API client + formatting helpers
+  lib/suggestions.ts    # suggestion computation logic
+  components/           # ResourceBar, PodRow, DeploymentCard, SuggestionPanel, Sparkline...
+  app/
+    page.tsx            # login
+    dashboard/page.tsx  # main dashboard
+```
+
+## Guidelines
+
+- **Backend**: No client-go. All Kubernetes API calls go through `k8s/client.go` (raw HTTP). Keep the backend stateless — no caching, no database.
+- **Frontend**: No UI library. CSS Modules only. No charting libraries — sparklines use pure SVG.
+- **Suggestions**: Thresholds live in `frontend/src/lib/suggestions.ts`. Keep them configurable.
+- **RBAC**: Any new Kubernetes resource access must be added to `helm/kubeadjust/templates/rbac.yaml`.
+
+## Pull request checklist
+
+- [ ] `go vet ./...` passes in `backend/`
+- [ ] `npm run build` passes in `frontend/`
+- [ ] New env vars are documented in README.md
+- [ ] Helm values are documented in `values.yaml`
+
+## Reporting bugs
+
+Please use the [bug report template](.github/ISSUE_TEMPLATE/bug_report.yml).
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the Apache 2.0 License.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,34 @@
+# Security Policy
+
+## Supported versions
+
+| Version | Supported |
+|---------|-----------|
+| 0.2.x   | Yes       |
+| 0.1.x   | No        |
+
+## Reporting a vulnerability
+
+Please **do not** open a public GitHub issue for security vulnerabilities.
+
+Instead, report them privately via [GitHub Security Advisories](https://github.com/thomas6013/devops-kubeadjust/security/advisories/new).
+
+Include:
+- A description of the vulnerability
+- Steps to reproduce
+- Potential impact
+- A suggested fix if you have one
+
+You can expect an acknowledgement within 72 hours and a fix or mitigation plan within 14 days.
+
+## Security model
+
+KubeAdjust is **read-only** and **stateless**:
+
+- The backend has no database, no cache, and no persistent state
+- The user's service account token is stored in `sessionStorage` only (cleared on tab close)
+- The token is forwarded as-is to the Kubernetes API — Kubernetes RBAC enforces all permissions
+- The backend never logs tokens or credentials
+- All Kubernetes API access requires a valid Bearer token supplied by the user
+
+The Helm chart deploys with minimal RBAC (read-only ClusterRole) and a hardened container security context (`readOnlyRootFilesystem`, `runAsNonRoot`, `allowPrivilegeEscalation: false`, all capabilities dropped).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,30 @@
+services:
+  backend:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+    ports:
+      - "8080:8080"
+    environment:
+      PORT: "8080"
+      # Point to your cluster API server
+      KUBE_API_SERVER: "${KUBE_API_SERVER:-https://kubernetes.default.svc}"
+      # Set to true if your cluster uses a self-signed certificate
+      KUBE_INSECURE_TLS: "${KUBE_INSECURE_TLS:-false}"
+      # Optional: connect to an existing Prometheus for sparklines
+      # PROMETHEUS_URL: "http://prometheus:9090"
+    restart: unless-stopped
+
+  frontend:
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile
+      args:
+        BACKEND_URL: "http://backend:8080"
+    ports:
+      - "3000:3000"
+    environment:
+      BACKEND_URL: "http://backend:8080"
+    depends_on:
+      - backend
+    restart: unless-stopped

--- a/helm/kubeadjust/Chart.yaml
+++ b/helm/kubeadjust/Chart.yaml
@@ -13,6 +13,6 @@ keywords:
 
 dependencies:
   - name: metrics-server
-    version: "3.12.2"
+    version: "3.13.0"
     repository: "https://kubernetes-sigs.github.io/metrics-server/"
     condition: metricsServer.enabled

--- a/helm/kubeadjust/values.yaml
+++ b/helm/kubeadjust/values.yaml
@@ -6,7 +6,7 @@ fullnameOverride: ""
 backend:
   image:
     repository: ghcr.io/thomas6013/devops-kubeadjust/kubeadjust-backend
-    tag: "0.1.0"
+    tag: "0.2.0"
     pullPolicy: Always
     pullSecrets:
       - ghcr-login-secret
@@ -26,7 +26,7 @@ backend:
 frontend:
   image:
     repository: ghcr.io/thomas6013/devops-kubeadjust/kubeadjust-frontend
-    tag: "0.1.0"
+    tag: "0.2.0"
     pullPolicy: Always
     pullSecrets:
       - ghcr-login-secret


### PR DESCRIPTION
- Metrics-server detection: banner shown when unavailable
- Prometheus sparklines: optional inline CPU/memory history charts
- StatefulSet + CronJob support with owner-reference pod mapping
- Fix CPU metrics parsing (nanocores suffix)
- Suggestion panel grouped by resource type, collapsible sections
- Helm chart v0.2.0: metrics-server optional dep, PROMETHEUS_URL support
- Open-source cleanup: README, CONTRIBUTING, CHANGELOG, SECURITY, CI, templates